### PR TITLE
fix(au-select-custom-attribute): use DOM.Element

### DIFF
--- a/src/au-select-custom-attribute.js
+++ b/src/au-select-custom-attribute.js
@@ -1,7 +1,7 @@
-import {Element} from 'aurelia-framework';
+import {DOM} from 'aurelia-framework';
 
 export class AuSelectCustomAttribute {
-  static inject = [Element];
+  static inject = [DOM.Element];
 
   constructor(element) {
     element._updateItems = function() {


### PR DESCRIPTION
`aurelia-framework` does not export `Element` resulting in error 

```
Unhandled rejection Error: Error invoking AuSelectCustomAttribute. Check the inner error for details.
------------------------------------------------
Inner Error:
Message: key/value cannot be null or undefined. Are you trying to inject/register something that doesn't exist with DI?
```

This PR fixes that.
